### PR TITLE
 Suggestion de simplification du Equals

### DIFF
--- a/Assets/Scripts/Node.cs
+++ b/Assets/Scripts/Node.cs
@@ -101,7 +101,7 @@ public class Node : IComparable<Node>
     public override bool Equals(object obj)
     {
         var n = obj as Node;
-        return Point.X == n?.Point.X && Point.Y == n?.Point.Y;
+        return Point.X == n?.Point?.X && Point.Y == n?.Point?.Y;
     }
 
     public override int GetHashCode()

--- a/Assets/Scripts/Node.cs
+++ b/Assets/Scripts/Node.cs
@@ -100,12 +100,8 @@ public class Node : IComparable<Node>
 
     public override bool Equals(object obj)
     {
-        if (obj == null || GetType() != obj.GetType())
-            return false;
-        var n = (Node)obj;
-        if (n.Point == null)
-            return false;
-        return Point.X == n.Point.X && Point.Y == n.Point.Y;
+        var n = obj as Node;
+        return Point.X == n?.Point.X && Point.Y == n?.Point.Y;
     }
 
     public override int GetHashCode()


### PR DESCRIPTION
En C#6, tu peux simplifier ton Equals ainsi.
As => cast dans le type indiqué si possible, sinon retourne null.
?. => Null conditional operator : si ta valeur de gauche est différente de null il traite l'élément de droite, sinon retourne directement null sans traiter la suite.
